### PR TITLE
Expose pg.defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ then(function (results) {
 })
 ```
 
-Also, `getConnection.end` is equivalent to [`pg.end`](https://github.com/brianc/node-postgres/wiki/pg#end)
+Also, `getConnection.end` is equivalent to [`pg.end`](https://github.com/brianc/node-postgres/wiki/pg#end). Similarly, `getConnection.defaults` is equivalent to [`pg.defauts`](https://github.com/brianc/node-postgres/wiki/pg#pgdefaults).
 
 Testing
 -------

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = function (config) {
   }
 
   getConnection.withTransaction = withTransaction
+  getConnection.defaults = pg.defaults
   getConnection.end = pg.end.bind(pg)
   getConnection.on = eventEmitter.on.bind(eventEmitter)
 


### PR DESCRIPTION
This exposes `pg.defaults` so that things like `parseInt8` can be set.