### PR TITLE
provide access to unpromisified version of client.query

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ module.exports = function (config) {
       .spread(function (client, done) {
         eventEmitter.emit('client', client)
         close = done
-        return Promise.promisify(client.query, { context: client })
+
+        var promised = Promise.promisify(client.query, { context: client })
+        promised.nodeVersion = client.query
+
+        return promised
       })
       .disposer(function (query) {
         if (close) { close() }


### PR DESCRIPTION
Very minor change - provides access to the unpromisified version of `client.query` as `query.nodeVersion` while leaving everything else as is.

A million thanks to @pythonesque for instructing me on what the problem here was, as I would not be able to use the [pg-copy-streams](https://github.com/brianc/node-pg-copy-streams) package in conjunction with the promisified client; I needed access to the unpromisifed one.